### PR TITLE
Add PostHog handbook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ Company Handbooks
 - [Niteo](https://github.com/niteoweb/handbook)
 - [Nylas](https://github.com/nylas/handbook)
 - [Pinpoint](https://github.com/pinpt/handbook)
+- [Posthog](https://posthog.com/handbook)
 - [source{d}](https://github.com/src-d/guide)
 - [sourcegraph](https://github.com/sourcegraph/handbook)
 - [sophilabs](https://github.com/sophilabs/playbook)


### PR DESCRIPTION
Found this handbook in the 2022-08-22 issue of the YC newsletter, but didn't read it yet.
Posthog is an open source product analytics (and more), but I have no affiliation with it.