### PR TITLE
Add RocketChat handbook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Company Handbooks
 - [Niteo](https://github.com/niteoweb/handbook)
 - [Posthog](https://posthog.com/handbook)
 - [Remote](https://remotecom.notion.site/a3439c6ccaac4d5f8c7515c357345c11?v=8bb7f9be662f45da87ef4ab14a42be37)
+- [RocketChat](https://handbook.rocket.chat/)
 - [sourcegraph](https://github.com/sourcegraph/handbook)
 - [sophilabs](https://sophilabs.notion.site/Playbook-956e7c5ff4b544f4be17fde1dc8d895d)
 - [Sparksuite](https://handbook.sparksuite.com/)


### PR DESCRIPTION
RocketChat has a pretty good handbook that can be seen here: https://handbook.rocket.chat/. It'd definitely be a great addition to this list.
